### PR TITLE
Match package name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "cfa-sero-protection"
+name = "seropro"
 version = "0.1.0"
 description = ""
 authors = ["Edward Schrom <tec0@cdc.gov>"]


### PR DESCRIPTION
Without this change, `poetry install` tries to install a package named `cfa-sero-protection` and can't find it. This way you get `seropro` installed in the virtual env