### PR TITLE
Fix the way protection distributions are calculated

### DIFF
--- a/scripts/scratch.py
+++ b/scripts/scratch.py
@@ -26,6 +26,10 @@ curves.plot(spu.calculate_risk_dslogit)
 risks = titers.to_risk(curves, spu.calculate_risk_dslogit)
 risks.to_density(values="risk", groups="par_id").plot()
 
-# %% Calculate protections for risks and plot their distribution
+# %% Calculate odds-ratio protections for risks and plot their distribution
 prots = risks.to_protection(spu.calculate_protection_oddsratio)
+prots.to_density(values="protection", groups="par_id").plot()
+
+# %% Calculate risk-ratio protections for risks and plot their distribution
+prots = risks.to_protection(spu.calculate_protection_riskratio)
 prots.to_density(values="protection", groups="par_id").plot()

--- a/seropro/samples.py
+++ b/seropro/samples.py
@@ -131,10 +131,14 @@ class RiskSamples(Samples):
         assert (self["risk"] <= 1.0).all(), "Some risks >1."
 
     def to_protection(self, prot_func: Callable) -> "ProtectionSamples":
+        """
+        Protection is calculated relative to the lowest observed titer,
+        but it should be relative to the lowest observable titer.
+        """
         args = prot_func.__code__.co_varnames[: prot_func.__code__.co_argcount]
         assert args == ("risk",), "Bad function"
         prot_samples = self.with_columns(
-            protection=prot_func(pl.col("risk"))
+            protection=prot_func(pl.col("risk").over("par_id"))
         ).drop("risk")
 
         return ProtectionSamples(prot_samples)

--- a/seropro/samples.py
+++ b/seropro/samples.py
@@ -9,13 +9,22 @@ import seropro.utils
 from seropro.densities import Density
 
 
-class Samples(pl.DataFrame):
+class Samples:
     """
-    Samples drawn from any distribution.
+    Samples drawn from any distribution, and optionally
+    the bounds of that distribution's support.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        draws: pl.DataFrame,
+        bounds: pl.DataFrame | None,
+    ):
+        self.draws = draws
+
+        if bounds is not None:
+            self.bounds = bounds
+
         self.validate()
 
     def validate(self):
@@ -24,16 +33,25 @@ class Samples(pl.DataFrame):
     def to_density(
         self, values: str, groups: str | None, bins: int = 1000
     ) -> Density:
-        x_vals = np.linspace(
-            np.array(self[values].min()), np.array(self[values].max()), bins
-        )
+        if hasattr(self, "bounds"):
+            x_vals = np.linspace(
+                np.array(self.bounds[values].min()),
+                np.array(self.bounds[values].max()),
+                bins,
+            )
+        else:
+            x_vals = np.linspace(
+                np.array(self.draws[values].min()),
+                np.array(self.draws[values].max()),
+                bins,
+            )
         if groups is None:
-            kde = gaussian_kde(self[values].to_numpy())
+            kde = gaussian_kde(self.draws[values].to_numpy())
             density = pl.DataFrame({values: x_vals, "density": kde(x_vals)})
         else:
             density = pl.DataFrame()
-            for i in self[groups].unique():
-                group = self.filter(pl.col(groups) == i)
+            for i in self.draws[groups].unique():
+                group = self.draws.filter(pl.col(groups) == i)
                 kde = gaussian_kde(group[values].to_numpy())
                 group_density = pl.DataFrame(
                     {
@@ -44,7 +62,7 @@ class Samples(pl.DataFrame):
                 )
                 density = density.vstack(
                     group_density.with_columns(
-                        pl.col(groups).cast(self[groups].dtype)
+                        pl.col(groups).cast(self.draws[groups].dtype)
                     )
                 )
 
@@ -53,40 +71,53 @@ class Samples(pl.DataFrame):
 
 class TiterSamples(Samples):
     """
-    Antibody titer samples drawn from a distribution of individuals in a population.
+    Antibody titer samples drawn from a distribution of individuals in a population,
+    plus the bounds of observable titers.
     """
 
     def validate(self):
         seropro.utils.validate_schema(
-            {"titer": pl.Float64, "pop_id": pl.UInt32}, self.schema
+            {"titer": pl.Float64, "pop_id": pl.UInt32}, self.draws.schema
         )
-        assert (self["titer"] >= 0.0).all(), "Some titers <0."
+        assert (self.draws["titer"] >= 0.0).all(), "Some titers <0."
+        assert hasattr(self, "bounds"), "Titer bounds are missing."
+        seropro.utils.validate_schema(
+            {"titer": pl.Float64, "pop_id": pl.UInt32}, self.bounds.schema
+        )
+        assert self.bounds.shape == (2, 2), "More than two bounds."
+        assert self.bounds["titer"][1] > self.bounds["titer"][0], "Min > max."
 
     def to_risk(
         self, curves: "CurveSamples", risk_func: Callable
     ) -> "RiskSamples":
-        par_samples = curves.pivot(on="par", values="val")
+        par_samples = curves.draws.pivot(on="par", values="val")
         args = risk_func.__code__.co_varnames[: risk_func.__code__.co_argcount]
-        risk_samples = self.join(par_samples, how="cross")
-        assert all(arg in risk_samples.columns for arg in args), "Bad function"
         cols = tuple(pl.col(arg) for arg in args)
+        risk_samples = self.draws.join(par_samples, how="cross")
+        assert all(arg in risk_samples.columns for arg in args), "Bad function"
         risk_samples = risk_samples.with_columns(risk=risk_func(*cols)).select(
             ["risk", "pop_id", "par_id"]
         )
+        risk_bounds = self.bounds.join(par_samples, how="cross")
+        risk_bounds = risk_bounds.with_columns(risk=risk_func(*cols)).select(
+            ["risk", "pop_id", "par_id"]
+        )
 
-        return RiskSamples(risk_samples)
+        return RiskSamples(risk_samples, risk_bounds)
 
 
 class CurveSamples(Samples):
     """
     Samples drawn from a posterior distribution of parameter values of a risk curve.
+    Bounds on the support of the distribution are not considered here.
     """
 
     def validate(self):
         seropro.utils.validate_schema(
             {"par": pl.String, "val": pl.Float64, "par_id": pl.UInt32},
-            self.schema,
+            self.draws.schema,
         )
+        assert not hasattr(self, "bounds"), "Bounds should not exist."
 
     def plot(
         self,
@@ -100,9 +131,14 @@ class CurveSamples(Samples):
                 {
                     "titer": np.linspace(titer_min, titer_max, bins),
                 }
-            ).with_row_index("pop_id")
+            ).with_row_index("pop_id"),
+            pl.DataFrame({"titer": [titer_min, titer_max]}).with_row_index(
+                "pop_id"
+            ),
         )
-        risks = titers.to_risk(self, risk_func).join(titers, on="pop_id")
+        risks = titers.to_risk(self, risk_func).draws.join(
+            titers.draws, on="pop_id"
+        )
         alt.data_transformers.disable_max_rows()
         mean_risk = risks.group_by("titer").agg(risk=pl.col("risk").mean())
         output = alt.Chart(risks).mark_line(opacity=0.1).encode(
@@ -125,10 +161,16 @@ class RiskSamples(Samples):
     def validate(self):
         seropro.utils.validate_schema(
             {"risk": pl.Float64, "pop_id": pl.UInt32, "par_id": pl.UInt32},
-            self.schema,
+            self.draws.schema,
         )
-        assert (self["risk"] >= 0.0).all(), "Some risks <0."
-        assert (self["risk"] <= 1.0).all(), "Some risks >1."
+        assert (self.draws["risk"] >= 0.0).all(), "Some risks <0."
+        assert (self.draws["risk"] <= 1.0).all(), "Some risks >1."
+        assert hasattr(self, "bounds"), "Risk bounds are missing."
+        seropro.utils.validate_schema(
+            {"risk": pl.Float64, "pop_id": pl.UInt32, "par_id": pl.UInt32},
+            self.bounds.schema,
+        )
+        assert set(self.bounds["pop_id"].unique()) == {0, 1}, ">2 bounds."
 
     def to_protection(self, prot_func: Callable) -> "ProtectionSamples":
         """
@@ -136,12 +178,18 @@ class RiskSamples(Samples):
         but it should be relative to the lowest observable titer.
         """
         args = prot_func.__code__.co_varnames[: prot_func.__code__.co_argcount]
-        assert args == ("risk",), "Bad function"
-        prot_samples = self.with_columns(
-            protection=prot_func(pl.col("risk").over("par_id"))
-        ).drop("risk")
+        assert args == ("risk", "max_risk"), "Bad function"
+        max_risks = (
+            self.bounds.filter("pop_id" == 0)
+            .drop("pop_id")
+            .rename({"risk": "max_risk"})
+        )
+        risks = self.draws.join(max_risks, on="par_id")
+        prot_samples = risks.with_columns(
+            protection=prot_func(pl.col("risk"), pl.col("max_risk"))
+        ).drop(["risk", "max_risk"])
 
-        return ProtectionSamples(prot_samples)
+        return ProtectionSamples(prot_samples, None)
 
 
 class ProtectionSamples(Samples):
@@ -157,10 +205,11 @@ class ProtectionSamples(Samples):
                 "pop_id": pl.UInt32,
                 "par_id": pl.UInt32,
             },
-            self.schema,
+            self.draws.schema,
         )
-        assert (self["protection"] >= 0.0).all(), "Some protections <0."
-        assert (self["protection"] <= 1.0).all(), "Some protections >1."
+        assert (self.draws["protection"] >= 0.0).all(), "Some protections <0."
+        assert (self.draws["protection"] <= 1.0).all(), "Some protections >1."
+        assert not hasattr(self, "bounds"), "Bounds should not exist."
 
 
 def simulate_titers(dists: List[tuple], seed: int = 0):
@@ -178,7 +227,10 @@ def simulate_titers(dists: List[tuple], seed: int = 0):
         assert hasattr(rng, dist[0]), "{dist[0]} is not a distribution."
         titers = titers + getattr(rng, dist[0])(*dist[1:]).tolist()
     titer_samples = pl.DataFrame({"titer": titers}).with_row_index("pop_id")
-    return TiterSamples(titer_samples)
+    titer_bounds = pl.DataFrame(
+        {"titer": [0, titer_samples["titer"].max()]}
+    ).with_row_index("pop_id")
+    return TiterSamples(titer_samples, titer_bounds)
 
 
 def simulate_curve(dists: Dict[str, tuple], seed: int = 0):
@@ -203,4 +255,4 @@ def simulate_curve(dists: Dict[str, tuple], seed: int = 0):
     draws = draws.with_row_index("par_id").unpivot(
         index="par_id", variable_name="par", value_name="val"
     )
-    return CurveSamples(draws)
+    return CurveSamples(draws, None)

--- a/seropro/samples.py
+++ b/seropro/samples.py
@@ -180,7 +180,7 @@ class RiskSamples(Samples):
         args = prot_func.__code__.co_varnames[: prot_func.__code__.co_argcount]
         assert args == ("risk", "max_risk"), "Bad function"
         max_risks = (
-            self.bounds.filter("pop_id" == 0)
+            self.bounds.filter(pl.col("pop_id") == 0)
             .drop("pop_id")
             .rename({"risk": "max_risk"})
         )
@@ -193,7 +193,7 @@ class RiskSamples(Samples):
         )
         prot_bounds = risk_bounds.with_columns(
             protection=prot_func(pl.col("risk"), pl.col("max_risk"))
-        ).drop(["risk"], ["max_risk"])
+        ).drop(["risk", "max_risk"])
 
         return ProtectionSamples(prot_samples, prot_bounds)
 

--- a/seropro/samples.py
+++ b/seropro/samples.py
@@ -122,8 +122,8 @@ class CurveSamples(Samples):
     def plot(
         self,
         risk_func: Callable,
-        titer_min: float = 0,
-        titer_max: float = 1000,
+        titer_min: float = 0.0,
+        titer_max: float = 1000.0,
         bins: int = 1000,
     ):
         titers = TiterSamples(

--- a/seropro/samples.py
+++ b/seropro/samples.py
@@ -243,7 +243,7 @@ def simulate_titers(dists: List[tuple], seed: int = 0):
         titers = titers + getattr(rng, dist[0])(*dist[1:]).tolist()
     titer_samples = pl.DataFrame({"titer": titers}).with_row_index("pop_id")
     titer_bounds = pl.DataFrame(
-        {"titer": [0, titer_samples["titer"].max()]}
+        {"titer": [0.0, titer_samples["titer"].max()]}
     ).with_row_index("pop_id")
     return TiterSamples(titer_samples, titer_bounds)
 

--- a/seropro/utils.py
+++ b/seropro/utils.py
@@ -29,4 +29,28 @@ def calculate_protection_oddsratio(risk: pl.Expr, max_risk: pl.Expr):
     Calculate protection using the odds ratio definition,
     using the greatest risk as the baseline for comparison.
     """
-    return 1 - (risk / (1 - risk) / (max_risk / (1 - max_risk)))
+    adj = 0.000001
+    risk = pl.when(risk == 0.0).then(adj).otherwise(risk)
+    risk = pl.when(risk == 1.0).then(risk - adj).otherwise(risk)
+    max_risk = pl.when(max_risk == 0.0).then(adj).otherwise(max_risk)
+    max_risk = (
+        pl.when(max_risk == 1.0).then(max_risk - adj).otherwise(max_risk)
+    )
+
+    return 1 - ((risk / (1 - risk)) / (max_risk / (1 - max_risk)))
+
+
+def calculate_protection_riskratio(risk: pl.Expr, max_risk: pl.Expr):
+    """
+    Calculate protection using the risk ratio definition,
+    using the greatest risk as the baseline for comparison.
+    """
+    adj = 0.000001
+    risk = pl.when(risk == 0.0).then(adj).otherwise(risk)
+    risk = pl.when(risk == 1.0).then(risk - adj).otherwise(risk)
+    max_risk = pl.when(max_risk == 0.0).then(adj).otherwise(max_risk)
+    max_risk = (
+        pl.when(max_risk == 1.0).then(max_risk - adj).otherwise(max_risk)
+    )
+
+    return 1 - (risk / max_risk)

--- a/seropro/utils.py
+++ b/seropro/utils.py
@@ -24,9 +24,9 @@ def calculate_risk_dslogit(
     return min + (max - min) / (1 + (slope * (titer - mid)).exp())
 
 
-def calculate_protection_oddsratio(risk: pl.Expr):
+def calculate_protection_oddsratio(risk: pl.Expr, max_risk: pl.Expr):
     """
     Calculate protection using the odds ratio definition,
     using the greatest risk as the baseline for comparison.
     """
-    return 1 - (risk / (1 - risk) / (risk.max() / (1 - risk.max())))
+    return 1 - (risk / (1 - risk) / (max_risk / (1 - max_risk)))

--- a/tests/samples.py
+++ b/tests/samples.py
@@ -139,17 +139,11 @@ def test_to_protection_right_func(titers, curves):
         protection=pl.col("protection").round(2)
     )
 
-        {
-            "pop_id": [0, 1, 2, 0, 1, 2, 0, 1, 2],
-            "par_id": [0, 0, 0, 1, 1, 1, 2, 2, 2],
-            "risk": [1.0, 0.5, 0.0, 0.9, 0.9, 0.5, 0.5, 0.2, 0.2],
-        }
-
     expected_draws = pl.DataFrame(
         {
             "pop_id": [0, 1, 2, 0, 1, 2, 0, 1, 2],
             "par_id": [0, 0, 0, 1, 1, 1, 2, 2, 2],
-            "protection": [0.0, 0.0, 1.0, 0.0, 0.0, 0.89, 0.0, 0.94, 0.94],
+            "protection": [0.0, 1.0, 1.0, 0.0, 0.0, 0.89, 0.0, 0.75, 0.75],
         }
     ).with_columns(
         pop_id=pl.col("pop_id").cast(pl.UInt32),
@@ -160,7 +154,7 @@ def test_to_protection_right_func(titers, curves):
         {
             "pop_id": [0, 1, 0, 1, 0, 1],
             "par_id": [0, 0, 1, 1, 2, 2],
-            "protection": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+            "protection": [0.0, 1.0, 0.0, 0.99, 0.0, 0.75],
         }
     ).with_columns(
         pop_id=pl.col("pop_id").cast(pl.UInt32),


### PR DESCRIPTION
Previously, I had been using the minimum titer observed in the titer data to find the maximum risk with which to calculate protection. But the minimum titer observed might not be the minimum titer observable. The latter quantity is the appropriate one to use.

Previously, I had been using the global maximum risk (derived from the minimum titer) across _all_ risk curve parameter sets to calculate protection. But the maximum risk (derived from the minimum titer) _within_ each risk curve parameter set will not always be equal to the global maximum risk. The latter is the appropriate way to calculate protection distributions for each risk curve parameter set separately.

To fix both of these issues, I introduced a second attribute to the `Samples` class - a data frame of the maximum and minimum values in theory. The addition of this attribute required many small changes in `samples.py` as well as updated and new tests.

Finally, I also added a second protection function, using the risk ratio rather than the odds ratio.